### PR TITLE
Add simple local-storage backed to-do app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
 
+### To‑Do Demo
+
+This repository also includes a small to‑do application for demonstration purposes. Run the development server and navigate to [`/todo`](http://localhost:3000/todo) to try it out. Tasks are stored in your browser so you can refresh the page without losing them.
+
 [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.

--- a/pages/todo.tsx
+++ b/pages/todo.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from "react";
+
+interface Todo {
+  id: number;
+  text: string;
+  done: boolean;
+}
+
+export default function TodoPage() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [input, setInput] = useState("");
+
+  // Load todos from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem("todos");
+    if (stored) {
+      try {
+        setTodos(JSON.parse(stored));
+      } catch {
+        // ignore malformed storage
+      }
+    }
+  }, []);
+
+  // Persist todos whenever they change
+  useEffect(() => {
+    localStorage.setItem("todos", JSON.stringify(todos));
+  }, [todos]);
+
+  const addTodo = () => {
+    if (!input.trim()) return;
+    setTodos([...todos, { id: Date.now(), text: input.trim(), done: false }]);
+    setInput("");
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos(
+      todos.map((todo) =>
+        todo.id === id ? { ...todo, done: !todo.done } : todo
+      )
+    );
+  };
+
+  const removeTodo = (id: number) => {
+    setTodos(todos.filter((todo) => todo.id !== id));
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center py-10 bg-gray-100">
+      <h1 className="text-2xl font-bold mb-6">My To-Do List</h1>
+      <div className="flex w-full max-w-md">
+        <input
+          className="flex-grow border border-gray-300 rounded-l px-3 py-2 focus:outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Add a task"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") addTodo();
+          }}
+        />
+        <button
+          onClick={addTodo}
+          className="bg-blue-500 text-white px-4 py-2 rounded-r hover:bg-blue-600"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="w-full max-w-md mt-4">
+        {todos.map((todo) => (
+          <li
+            key={todo.id}
+            className="flex items-center justify-between bg-white p-2 my-2 rounded shadow"
+          >
+            <span
+              onClick={() => toggleTodo(todo.id)}
+              className={`flex-grow cursor-pointer select-none ${
+                todo.done ? "line-through text-gray-500" : ""
+              }`}
+            >
+              {todo.text}
+            </span>
+            <button
+              onClick={() => removeTodo(todo.id)}
+              className="text-red-500 ml-4 hover:text-red-700"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/todo` page implementing a minimal to-do list with local storage persistence
- document the to-do demo in the README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_689f5617a1288328952f129fe84313e6